### PR TITLE
add  field for Node; cycle detection in Graphs.randomWalk()

### DIFF
--- a/lick/collect/Graphs.ck
+++ b/lick/collect/Graphs.ck
@@ -40,6 +40,10 @@ public class Graphs
         {
             node.outEdges.sample() $ Edge @=> Edge edge;
             edge.target @=> node;
+            // break cycle if we visited this node before
+            if( node.visited ) break;
+            // mark node as visited
+            true => node.visited;
             procedure.run(node);
         }
    }

--- a/lick/collect/Node.ck
+++ b/lick/collect/Node.ck
@@ -25,6 +25,7 @@ public class Node
     Object @ value;
     ArrayList inEdges;
     ArrayList outEdges;
+    int visited;
 
     fun int degree()
     {


### PR DESCRIPTION
Not sure if this is in the convention of LiCK, or if the proposed changes are entirely correct 😆 Since 1.5.1.1 we have add LiCK to our extended test set for chuck development. We noticed that running `chuck import.ck tests.ck` sometimes hangs on `GraphsTest.ck`. Further investigation suggests that the hanging seems to happen in `Graphs.randomWalk()` and may be the result of cycles in the graph (apropos of an existing TODO comment in the function). Hence we have these proposed additions to Node and Graphs.randomWalk(). Again, while these additions do seem to avoid hang-up, not sure if these are the preferred way to add cycle detection. In any case, wanted to get this on your radar. Thank you for LiCK!!